### PR TITLE
[COOK-3085] support enterprise install

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -24,8 +24,6 @@ default['sql_server']['port']           = 1433
 default['sql_server']['instance_name']  = 'SQLEXPRESS'
 default['sql_server']['instance_dir']   = 'C:\Program Files\Microsoft SQL Server'
 
-default['sql_server']['feature_list'] = 'SQLENGINE,REPLICATION,SNAC_SDK'
-
 if kernel['machine'] =~ /x86_64/
 
   default['sql_server']['server']['url']          = 'http://care.dlservice.microsoft.com/dl/download/5/1/A/51A153F6-6B08-4F94-A7B2-BA1AD482BC75/SQLEXPR_x64_ENU.exe'

--- a/templates/default/ConfigurationFile.ini.erb
+++ b/templates/default/ConfigurationFile.ini.erb
@@ -26,7 +26,7 @@ ACTION="Install"
 
 ; Specifies features to install, uninstall, or upgrade. The list of top-level features include SQL, AS, RS, IS, and Tools. The SQL feature will install the database engine, replication, and full-text. The Tools feature will install Management Tools, Books online, Business Intelligence Development Studio, and other shared components.
 
-FEATURES=<%= node['sql_server']['feature_list'] %>
+FEATURES=SQLENGINE,REPLICATION,SNAC_SDK
 
 ; Displays the command line parameters usage
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3085

Changed the service name to support an enterprise install.

Changed the config files settings for EnableRNU and AddCurrentUserAsSQLAdmin to be conditional as they must be false for an enterprise install.
