### PR TITLE
[COOK-3388] adds installer_timeout option to avoid the error - Mixlib::ShellOut::CommandTimeout: command timed out

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -26,6 +26,8 @@ default['sql_server']['instance_dir']   = 'C:\Program Files\Microsoft SQL Server
 
 default['sql_server']['feature_list'] = 'SQLENGINE,REPLICATION,SNAC_SDK'
 
+default['sql_server']['server']['installer_timeout'] = 1500
+
 if kernel['machine'] =~ /x86_64/
 
   default['sql_server']['server']['url']          = 'http://care.dlservice.microsoft.com/dl/download/5/1/A/51A153F6-6B08-4F94-A7B2-BA1AD482BC75/SQLEXPR_x64_ENU.exe'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -39,6 +39,7 @@ end
 windows_package node['sql_server']['server']['package_name'] do
   source node['sql_server']['server']['url']
   checksum node['sql_server']['server']['checksum']
+  timeout node['sql_server']['server']['installer_timeout']
   installer_type :custom
   options "/q /ConfigurationFile=#{config_file_path}"
   action :install


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3388
