### PR TITLE
[COOK-3506] SQLEXPRESS on 32 bits system do not support INSTALLSHAREDWOWDIR statement in ConfigurationFile.ini

### DIFF
--- a/templates/default/ConfigurationFile.ini.erb
+++ b/templates/default/ConfigurationFile.ini.erb
@@ -68,9 +68,11 @@ ERRORREPORTING="False"
 
 INSTALLSHAREDDIR="<%= node['sql_server']['install_dir'] %>"
 
+<% if node['kernel']['machine'] =~ /x86_64/ %>
 ; Specify the root installation directory for the WOW64 shared components.
 
 INSTALLSHAREDWOWDIR="C:\Program Files (x86)\Microsoft SQL Server"
+<% end %>
 
 ; Specify the installation directory.
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3506

The Configuration.ini.erb template sets the INSTALLSHAREDWOWDIR parameter, which is not supported on the 32-bits version. So, the SQL installation crashes on a Windows 7 32-bits system
