### PR TITLE
[COOK-3507] Fix broken download links for SQL Server

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -28,13 +28,13 @@ default['sql_server']['feature_list'] = 'SQLENGINE,REPLICATION,SNAC_SDK'
 
 if kernel['machine'] =~ /x86_64/
 
-  default['sql_server']['server']['url']          = 'http://care.dlservice.microsoft.com/dl/download/5/1/A/51A153F6-6B08-4F94-A7B2-BA1AD482BC75/SQLEXPR_x64_ENU.exe'
+  default['sql_server']['server']['url']          = 'http://download.microsoft.com/download/D/1/8/D1869DEC-2638-4854-81B7-0F37455F35EA/SQLEXPR_x64_ENU.exe'
   default['sql_server']['server']['checksum']     = '6840255cf493927a3f5e1d7f865b8409ed89133e3657a609da229bab4005b613'
   default['sql_server']['server']['package_name'] = 'Microsoft SQL Server 2008 R2 (64-bit)'
 
 else
 
-  default['sql_server']['server']['url']          = 'http://care.dlservice.microsoft.com/dl/download/5/1/A/51A153F6-6B08-4F94-A7B2-BA1AD482BC75/SQLEXPR32_x86_ENU.exe'
+  default['sql_server']['server']['url']          = 'http://download.microsoft.com/download/D/1/8/D1869DEC-2638-4854-81B7-0F37455F35EA/SQLEXPR32_x86_ENU.exe'
   default['sql_server']['server']['checksum']     = '24f75df802a406cf32e854a60b0c340a50865fb310c0f74c7cecc918cff6791c'
   default['sql_server']['server']['package_name'] = 'Microsoft SQL Server 2008 R2 (32-bit)'
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3507

The server SQL Express download links are broken, they return an HTTP "302 Moved Temporarily" response.
The broken links are:
http://care.dlservice.microsoft.com/dl/download/5/1/A/51A153F6-6B08-4F94-A7B2-BA1AD482BC75/SQLEXPR_x64_ENU.exe
http://care.dlservice.microsoft.com/dl/download/5/1/A/51A153F6-6B08-4F94-A7B2-BA1AD482BC75/SQLEXPR32_x86_ENU.exe
