### PR TITLE
Introduce Further Overriding Abilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ Analysis Services
 - `as_sysadmins` - Analysis Services Systems Administrator list. Default is `Administrator`
 - `as_account` - Service Account used by Analysis Services. Default is `NT Service\MSSQLServerOLAPService`
 - `as_account_pwd` - Service Account password for Analysis Services. Only needed if `as_account` is not default.
-- `as_data_dir` - Directory for Analysis Services data files. 
-- `as_log_dir` - Directory for Analysis Services log files.
-- `as_backup_dir` - Directory for Analysis Services backup files.
-- `as_temp_dir` - Directory for Analysis Services temporary files.
-- `as_config_dir` - Directory for Analysis Services configuration files.
+- `as_data_dir` - Directory for Analysis Services data files. Default is `Data`
+- `as_log_dir` - Directory for Analysis Services log files. Default is `Log`
+- `as_backup_dir` - Directory for Analysis Services backup files. Default is `Backup`
+- `as_temp_dir` - Directory for Analysis Services temporary files. Default is `Temp`
+- `as_config_dir` - Directory for Analysis Services configuration files. Default is `Config`
 
 
 PolyBase Query Services

--- a/README.md
+++ b/README.md
@@ -146,7 +146,14 @@ Reporting Services
 
 Analysis Services
 - `as_sysadmins` - Analysis Services Systems Administrator list. Default is `Administrator`
-- `as_svc_account` - Service Account used by Analysis Services. Default is `NT Service\MSSQLServerOLAPService`
+- `as_account` - Service Account used by Analysis Services. Default is `NT Service\MSSQLServerOLAPService`
+- `as_account_pwd` - Service Account password for Analysis Services. Only needed if `as_account` is not default.
+- `as_data_dir` - Directory for Analysis Services data files. 
+- `as_log_dir` - Directory for Analysis Services log files.
+- `as_backup_dir` - Directory for Analysis Services backup files.
+- `as_temp_dir` - Directory for Analysis Services temporary files.
+- `as_config_dir` - Directory for Analysis Services configuration files.
+
 
 PolyBase Query Services
 - `polybase_port_range` - Port Range for the PolyBase Query Service. Default is `16450-16460`.
@@ -156,6 +163,8 @@ Integrated Services
 - `is_master_ssl_cert` - The CNs in the certificate used to protect communications between the integration services scale out worker and scale out master.
 - `is_master_cert_thumbprint` - The certificate thumbprint for the scale out master ssl certificate.
 - `is_worker_master_url` - The url of the scale out master when installing a scale out worker.
+- `is_account` - Service Account used by Integrated Services. Default is `NT AUTHORITY\NetworkService`
+- `is_account_pwd` - Service Account password for Analysis Services. Only needed if `is_account` is not default.
 
 #### Examples
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -56,6 +56,8 @@ passwords_options = {
   AGTSVCPASSWORD: node['sql_server']['agent_account_pwd'],
   RSSVCPASSWORD: node['sql_server']['rs_account_pwd'],
   SQLSVCPASSWORD: node['sql_server']['sql_account_pwd'],
+  ASSVCPASSWORD: node['sql_server']['as_account_pwd'],
+  ISSVCPASSWORD: node['sql_server']['is_account_pwd']
 }.map do |option, attribute|
   next unless attribute
   # Escape password double quotes and backslashes

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -62,7 +62,15 @@ property :is_master_port, String, default: '8391'
 property :is_master_ssl_cert, String
 property :is_master_cert_thumbprint, String
 property :is_worker_master_url, String
-property :as_svc_account, String, default: 'NT Service\MSSQLServerOLAPService'
+property :as_account, String, default: 'NT Service\MSSQLServerOLAPService'
+property :as_account_pwd, String
+property :is_account, String, default: 'NT AUTHORITY\NetworkService'
+property :is_account_pwd, String
+property :as_data_dir, String, default: "Data"
+property :as_log_dir, String, default: "Log"
+property :as_backup_dir, String, default: "Backup"
+property :as_temp_dir, String, default: "Temp"
+property :as_config_dir, String, default: "Config"
 
 action :install do
   if new_resource.feature.include?('DREPLAY_CLT') && new_resource.dreplay_client_name.nil?
@@ -132,7 +140,13 @@ action :install do
       is_master_ssl_cert: new_resource.is_master_ssl_cert,
       is_master_cert_thumbprint: new_resource.is_master_cert_thumbprint,
       is_worker_master_url: new_resource.is_worker_master_url,
-      as_svc_account: new_resource.as_svc_account
+      as_account: new_resource.as_account,
+      is_account: new_resource.is_account,
+      as_data_dir: new_resource.as_data_dir,
+      as_log_dir: new_resource.as_log_dir,
+      as_backup_dir: new_resource.as_backup_dir,
+      as_temp_dir: new_resource.as_temp_dir,
+      as_config_dir: new_resource.as_config_dir
     )
     sensitive true
   end
@@ -155,6 +169,8 @@ action :install do
     AGTSVCPASSWORD: new_resource.agent_account_pwd,
     RSSVCPASSWORD: new_resource.rs_account_pwd,
     SQLSVCPASSWORD: new_resource.sql_account_pwd,
+    ASSVCPASSWORD: new_resource.as_account_pwd,
+    ISSVCPASSWORD: new_resource.is_account_pwd
   }.map do |option, attribute|
     next unless attribute
     # Escape password double quotes and backslashes

--- a/templates/default/_ConfigurationFile.ini.erb
+++ b/templates/default/_ConfigurationFile.ini.erb
@@ -157,7 +157,7 @@ ISSVCSTARTUPTYPE="Automatic"
 
 ; Account for Integration Services: Domain\User or system account.
 
-ISSVCACCOUNT="NT AUTHORITY\NetworkService"
+ISSVCACCOUNT="<%= @is_account %>"
 <% end %>
 
 ; A port number used to connect to the SharePoint Central Administration web application.
@@ -243,7 +243,7 @@ RSSHPINSTALLMODE="SharePointFilesOnlyMode"
 <% if @feature_list.include?('AS')%>
 ; The name of the account that the Analysis Services service runs under.
 
-ASSVCACCOUNT=<%= @as_svc_account %>
+ASSVCACCOUNT=<%= @as_account %>
 
 ; Controls the service startup type setting after the service has been created.
 
@@ -255,23 +255,23 @@ ASCOLLATION="Latin1_General_CI_AS"
 
 ; The location for the Analysis Services data files.
 
-ASDATADIR="Data"
+ASDATADIR="<%= @as_data_dir %>"
 
 ; The location for the Analysis Services log files.
 
-ASLOGDIR="Log"
+ASLOGDIR="<%= @as_log_dir %>"
 
 ; The location for the Analysis Services backup files.
 
-ASBACKUPDIR="Backup"
+ASBACKUPDIR="<%= @as_backup_dir %>"
 
 ; The location for the Analysis Services temporary files.
 
-ASTEMPDIR="Temp"
+ASTEMPDIR="<%= @as_temp_dir %>"
 
 ; The location for the Analysis Services configuration files.
 
-ASCONFIGDIR="Config"
+ASCONFIGDIR="<%= @as_config_dir %>"
 
 ; Specifies whether or not the MSOLAP provider is allowed to run in process.
 


### PR DESCRIPTION
Override Integrated Services Username/Password
Override Analysis Services Password and Directory Information

Signed-off-by: John Curcio <johnn.curcio@gmail.com>

### Description

- Override Integrated Services Username/Password.
- Override Analysis Services Password and Directory Information.

### Issues Resolved

Currently you can only override the Analysis Service Username which is pointless without overriding the password.

## My Concerns

- I am not sure if adding the ability to override the  Analysis Services & Integrated Services Password now requires you to install both services otherwise it fails
- Not sure how to note in the README the defaults for the Analysis Service Directory information. They were originally "Data", "Temp", "Backup", "Log" and "Config", which I assume varies per installation.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
