### PR TITLE
Add eula check

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+raise("node['sql_server']['accept_eula'] must be set to true for this cookbook to run") unless node['sql_server']['accept_eula']
 raise("node['sql_server']['server_sa_password'] must be set for this cookbook to run") if node['sql_server']['server_sa_password'].nil?
 
 config_file_path = win_friendly_path(File.join(Chef::Config[:file_cache_path], 'ConfigurationFile.ini'))


### PR DESCRIPTION
If "accept_eula" is required to install sql_server and the default value is false, we should let the user know instead of running the installer and letting it failing with a non-obvious error code

Obvious fix

# Description

Adds warning to required attribute for server install

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
