### PR TITLE
adding new checksums for Windows 20212 SQL component .msi packages

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -22,23 +22,23 @@ if node['kernel']['machine'] =~ /x86_64/
   case node['sql_server']['version']
   when '2012'
     default['sql_server']['native_client']['url']               = 'http://download.microsoft.com/download/F/E/D/FEDB200F-DE2A-46D8-B661-D019DFE9D470/ENU/x64/sqlncli.msi'
-    default['sql_server']['native_client']['checksum']          = '1364bf4c37a09ce3c87b029a2db4708f066074b1eaa22aa4e86d437b7b05203d'
+    default['sql_server']['native_client']['checksum']          = '5601a1969d12a72a16e3659712bc9727b3fd874b5f6f802fd1e042cac75cc069'
     default['sql_server']['native_client']['package_name']      = 'Microsoft SQL Server 2012 Native Client'
 
     default['sql_server']['command_line_utils']['url']          = 'http://download.microsoft.com/download/F/E/D/FEDB200F-DE2A-46D8-B661-D019DFE9D470/ENU/x64/SqlCmdLnUtils.msi'
-    default['sql_server']['command_line_utils']['checksum']     = 'ad9186c1acc786c116d0520fc642f6b315c4b8b62fc589d8e2763a2da4c80347'
+    default['sql_server']['command_line_utils']['checksum']     = '3f5cb4b876421286f8fd9666f00345a95d8ce1b6229baa6aeb2f076ef9e4aefe'
     default['sql_server']['command_line_utils']['package_name'] = 'Microsoft SQL Server 2012 Command Line Utilities'
 
     default['sql_server']['clr_types']['url']                   = 'http://download.microsoft.com/download/F/E/D/FEDB200F-DE2A-46D8-B661-D019DFE9D470/ENU/x64/SQLSysClrTypes.msi'
-    default['sql_server']['clr_types']['checksum']              = '674c396e9c9bf389dd21cec0780b3b4c808ff50c570fa927b07fa620db7d4537'
+    default['sql_server']['clr_types']['checksum']              = '4b2f86c3f001d6a13db25bf993f8144430db04bde43853b9f2e359aa4bd491d0'
     default['sql_server']['clr_types']['package_name']          = 'Microsoft SQL Server System CLR Types (x64)'
 
     default['sql_server']['smo']['url']                         = 'http://download.microsoft.com/download/F/E/D/FEDB200F-DE2A-46D8-B661-D019DFE9D470/ENU/x64/SharedManagementObjects.msi'
-    default['sql_server']['smo']['checksum']                    = 'ed753d85b51e7eae381085cad3dcc0f29c0b72f014f8f8fba1ad4e0fe387ce0a'
+    default['sql_server']['smo']['checksum']                    = '36d174cd87d5fc432beb4861863d8a7f944b812032727a6e7074a1fcab950faa'
     default['sql_server']['smo']['package_name']                = 'Microsoft SQL Server 2012 Management Objects (x64)'
 
     default['sql_server']['ps_extensions']['url']               = 'http://download.microsoft.com/download/F/E/D/FEDB200F-DE2A-46D8-B661-D019DFE9D470/ENU/x64/PowerShellTools.MSI'
-    default['sql_server']['ps_extensions']['checksum']          = '532261175cc6116439b89be476fa403737d85f2ee742f2958cf9c066bcbdeaba'
+    default['sql_server']['ps_extensions']['checksum']          = 'bb33e64659f7500d7f2088e3d5e7ac34a1bf13988736b8ba0075741fce1e67b6'
     default['sql_server']['ps_extensions']['package_name']      = 'Windows PowerShell Extensions for SQL Server 2012'
   end
 


### PR DESCRIPTION
# Description

In the last couple of days time (April 25-27, 2021 timeframe), Microsoft has changed the package checksums for packages installed with the sql_server chef supermarket cookbook. This is causing failures during chef-client runs.

I have added these new checksum values here that have resulted in my chef-client runs passing now.
