### PR TITLE
Limit ci integration parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           - os: windows-2012r2
             suite: server2019
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 2
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           - os: windows-2012r2
             suite: server2019
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 4
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           - os: windows-2012r2
             suite: server2019
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 5
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           - os: windows-2012r2
             suite: server2019
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           - os: windows-2012r2
             suite: server2019
       fail-fast: false
+      max-parallel: 4
 
     steps:
       - name: Check out code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the sql_server cookboo
 
 ## Unreleased
 
-- limit ci integration parallel jobs to 4 - [@jhboricua](https://github.com/jhboricua)
+- limit ci integration parallel jobs to avoid Vagrant image download rate-limiting errors - [@jhboricua](https://github.com/jhboricua)
 
 ## 7.0.0 - *2021-09-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the sql_server cookboo
 
 ## Unreleased
 
-- limit ci integration parallel jobs to avoid Vagrant image download rate-limiting errors - [@jhboricua](https://github.com/jhboricua)
+- Limit test kitchen parallel jobs to avoid Vagrant image download rate-limiting errors - [@jhboricua](https://github.com/jhboricua)
 
 ## 7.0.0 - *2021-09-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the sql_server cookboo
 
 ## Unreleased
 
+- limit ci integration parallel jobs to 4 - [@jhboricua](https://github.com/jhboricua)
+
 ## 7.0.0 - *2021-09-08*
 
 - Set environment flag to accept chef licence for CI jobs


### PR DESCRIPTION
# Description

limits number of CI integration jobs
## Issues Resolved

This attempts to avoid the rate-limit issue when downloading vagrant images that's causing the ci jobs to fail.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
