### PR TITLE
Pull vagrant images from OSUOSL to workaround rate limiting problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           CHEF_LICENSE: accept-no-persist
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
           KITCHEN_LOCAL_YAML: kitchen.platforms.yml
+          VAGRANT_CLOUD_TOKEN: ${{ secret.VAGRANT_CLOUD_TOKEN }}
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           CHEF_LICENSE: accept-no-persist
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
           KITCHEN_LOCAL_YAML: kitchen.platforms.yml
-          VAGRANT_CLOUD_TOKEN: ${{ secret.VAGRANT_CLOUD_TOKEN }}
+          VAGRANT_CLOUD_TOKEN: ${{ secrets.VAGRANT_CLOUD_TOKEN }}
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   # runs
   integration:
     needs: [mdl, yamllint, delivery]
-    runs-on: macos-latest
+    runs-on: macos-10.15
     strategy:
       matrix:
         os:
@@ -76,6 +76,7 @@ jobs:
         env:
           CHEF_LICENSE: accept-no-persist
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+          KITCHEN_LOCAL_YAML: kitchen.platforms.yml
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
         env:
           CHEF_LICENSE: accept-no-persist
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-          KITCHEN_LOCAL_YAML: kitchen.platforms.yml
           VAGRANT_CLOUD_TOKEN: ${{ secrets.VAGRANT_CLOUD_TOKEN }}
         with:
           suite: ${{ matrix.suite }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the sql_server cookboo
 
 ## Unreleased
 
+- Push change to see if we've fixed it
 - Pull vagrant images from OSUOSL to workaround rate limiting problems
 
 ## 7.1.0 - *2021-10-01*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the sql_server cookboo
 
 ## Unreleased
 
+- Pull vagrant images from OSUOSL to workaround rate limiting problems
+
 ## 7.1.0 - *2021-10-01*
 
 - Adds parameter for tempdb data and log file initial size

--- a/kitchen.platforms.yml
+++ b/kitchen.platforms.yml
@@ -1,11 +1,11 @@
 # Use boxes mirrored by OSUOSL to by-pass Hashicorp rate limiting on GitHub Actions
 platforms:
   - name: windows-2012r2
-    driver:
-      box_url: https://ftp.osuosl.org/pub/sous-chefs/bento/windows_2012r2.box
+    # driver:
+      # box_url: https://ftp.osuosl.org/pub/sous-chefs/bento/windows_2012r2.box
   - name: windows-2016
-    driver:
-      box_url: https://ftp.osuosl.org/pub/sous-chefs/bento/windows_2016.box
+    # driver:
+      # box_url: https://ftp.osuosl.org/pub/sous-chefs/bento/windows_2016.box
   - name: windows-2019
-    driver:
-      box_url: https://ftp.osuosl.org/pub/sous-chefs/bento/windows_2019.box
+    # driver:
+      # box_url: https://ftp.osuosl.org/pub/sous-chefs/bento/windows_2019.box

--- a/kitchen.platforms.yml
+++ b/kitchen.platforms.yml
@@ -1,0 +1,11 @@
+# Use boxes mirrored by OSUOSL to by-pass Hashicorp rate limiting on GitHub Actions
+platforms:
+  - name: windows-2012r2
+    driver:
+      box_url: https://ftp.osuosl.org/pub/sous-chefs/bento/windows_2012r2.box
+  - name: windows-2016
+    driver:
+      box_url: https://ftp.osuosl.org/pub/sous-chefs/bento/windows_2016.box
+  - name: windows-2019
+    driver:
+      box_url: https://ftp.osuosl.org/pub/sous-chefs/bento/windows_2019.box


### PR DESCRIPTION
Also use macos-10.15 which still includes vagrant/virtualbox.

Signed-off-by: Lance Albertson <lance@osuosl.org>
