### PR TITLE
Restricted X86=False for SQL 2022 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the sql_server cookboo
 
 ## Unreleased
 
+- Added support for SQL 2022 via resource installation method
+
 ## 7.1.13 - *2023-04-01*
 
 ## 7.1.12 - *2023-04-01*

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ together to maintain important cookbooks. If you’d like to know more please vi
 - Microsoft SQL Server 2016
 - Microsoft SQL Server 2017
 - Microsoft SQL Server 2019
+- Microsoft SQL Server 2022
 
 ### Supported Client Versions
 
@@ -101,7 +102,7 @@ together to maintain important cookbooks. If you’d like to know more please vi
         - `IS_MASTER` - Scale Out Master
         - `IS_WORKER` - Scale Out Worker
 
-- `version` - Version of SQL to be installed. Valid otpions are `2012`, `2016`, or `2017`. Default is `2012`
+- `version` - Version of SQL to be installed. Valid otpions are `2012`, `2016`, `2017`, `2019` or `2022`. Default is `2012`
 - `source_url` - Source of the SQL setup.exe install file. Default is built from the helper libraries.
 - `package_name` - Package name for the SQL install. If you specify a version this property is not necessary. Default is built from the helper libraries.
 - `package_checksum` - Package checksum in SHA256 format for the setup.exe file. Default is built from the helper libraries.

--- a/templates/_ConfigurationFile.ini.erb
+++ b/templates/_ConfigurationFile.ini.erb
@@ -58,9 +58,11 @@ QUIET="False"
 
 QUIETSIMPLE="False"
 
+<% if @version != '2022' %>
 ; Specifies that Setup should install into WOW64. This command line argument is not supported on an IA64 or a 32-bit system.
 
 X86="False"
+<% end%>
 
 ; Detailed help for command line argument ROLE has not been defined yet.
 
@@ -328,7 +330,7 @@ EXTSVCACCOUNT="NT Service\MSSQLLaunchpad"
 <% end %>
 <% end %>
 
-<% if (@version == '2016')  || (@version == '2017') || (@version == '2019') %>
+<% if (@version == '2016')  || (@version == '2017') || (@version == '2019') || (@version == '2022') %>
 ; Enables instant file initialization for SQL Server service account.
 SQLSVCINSTANTFILEINIT="<%= @sql_instant_file_init ? "True" : "False" %>"
 


### PR DESCRIPTION
# Description

Added conditions for SQL 2022 version which was stopping it to be installed.

## Issues Resolved

#194 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
